### PR TITLE
Add Bible verse lookup from Daily Dose titles

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ This is a customizable Python script that helps streamline your morning routine 
 
 ## 📌 Features
 
-- 📖 Fetches links to **Daily Dose of Hebrew and Greek**
+- 📖 Fetches links to **Daily Dose of Hebrew and Greek** and retrieves the verse text from RapidAPI
 - 🛠 Opens Bible study tools and documents
 - ⏲ Runs countdown timers for study and creative sessions
 - ☁️ Gets real-time **weather updates**
@@ -23,3 +23,9 @@ This is a customizable Python script that helps streamline your morning routine 
    ```bash
    git clone https://github.com/yourusername/morning-routine-assistant.git
    cd morning-routine-assistant
+   ```
+
+2. **Set environment variables** (`.env` file works):
+   - `YOUTUBE_TOKEN` – token for YouTube Data API
+   - `RAPIDAPI_KEY` – key for iq-bible API
+   - `RAPIDAPI_HOST` – host value for iq-bible API


### PR DESCRIPTION
## Summary
- map Bible book names to numeric codes
- extract Bible references from Daily Dose of Hebrew titles
- fetch the original verse text from the iq-bible API
- document environment variables for RapidAPI

## Testing
- `python3 -m py_compile 'Morning Helper.py'`

------
https://chatgpt.com/codex/tasks/task_e_6848cbf47ed083229a4dacb971bf25fc