### PR TITLE
Integrate contact modules

### DIFF
--- a/contact_scheduler.py
+++ b/contact_scheduler.py
@@ -93,6 +93,20 @@ def mark_called_this_month():
     state["called_this_month"] = True
     _save_state(state)
 
+
+def set_contact_lists(
+    monthly: list[str] | None = None, quarterly: list[str] | None = None
+) -> None:
+    """Replace the stored contact name lists."""
+    state = _load_state()
+    if monthly is not None:
+        state["monthly_contacts"] = list(monthly)
+        state["current_monthly_index"] = -1
+    if quarterly is not None:
+        state["quarterly_contacts"] = list(quarterly)
+        state["current_quarterly_index"] = -1
+    _save_state(state)
+
 def daily_prompt():
     """Print reminders for the current monthly and quarterly contacts."""
     monthly_contact = get_this_weeks_monthly_contact()

--- a/contact_storage.py
+++ b/contact_storage.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
 
-__all__ = ["load_contacts", "save_contacts", "update_contact"]
+__all__ = ["load_contacts", "save_contacts", "update_contact", "find_contact"]
 
 DEFAULT_FILE = Path("contacts.json")
 
@@ -78,4 +78,12 @@ def update_contact(
         new_contact = {"name": name}
         new_contact.update(fields)
         contacts.append(new_contact)
+
+
+def find_contact(contacts: List[Dict[str, Any]], name: str) -> Dict[str, Any] | None:
+    """Return the contact with ``name`` from *contacts* if present."""
+    for contact in contacts:
+        if contact.get("name") == name:
+            return contact
+    return None
 

--- a/note_prompt.py
+++ b/note_prompt.py
@@ -1,16 +1,38 @@
 from datetime import datetime
+
+from contact_scheduler import (
+    get_this_weeks_monthly_contact,
+    get_this_months_quarterly_contact,
+)
+from contact_storage import load_contacts, save_contacts, update_contact, find_contact
 from notes import prompt_for_update
 
 
 def main() -> None:
-    """Prompt the user to update notes based on the day of the week."""
+    """Prompt the user to update notes for today's scheduled contact."""
     weekday = datetime.today().weekday()  # Monday is 0
     if weekday in (0, 1):
-        prompt_for_update("monthly")
+        contact_name = get_this_weeks_monthly_contact()
     elif weekday == 2:
-        prompt_for_update("quarterly")
+        contact_name = get_this_months_quarterly_contact()
     else:
+        contact_name = None
+
+    if not contact_name:
         print("No contact notes scheduled today.")
+        return
+
+    contacts = load_contacts()
+    contact = find_contact(contacts, contact_name)
+    if contact:
+        print(f"Existing notes for {contact_name}:\n{contact.get('notes', '')}\n")
+    else:
+        print(f"Contact {contact_name} not found. It will be added.")
+
+    new_notes = prompt_for_update(contact_name)
+    if new_notes is not None:
+        update_contact(contacts, contact_name, notes=new_notes)
+        save_contacts(contacts)
 
 
 if __name__ == "__main__":

--- a/notes.py
+++ b/notes.py
@@ -8,31 +8,32 @@ NOTES_FILE = Path("notes.json")
 def load_notes() -> dict:
     """Load notes from ``NOTES_FILE``.
 
-    Returns a dictionary with ``monthly`` and ``quarterly`` keys.
+    The file stores a mapping of contact names to their note entries. If the
+    file doesn't exist, an empty mapping is returned.
     """
     if NOTES_FILE.is_file():
         with NOTES_FILE.open("r", encoding="utf-8") as fh:
             return json.load(fh)
-    return {"monthly": {}, "quarterly": {}}
+    return {}
 
 
 def save_notes(data: dict) -> None:
     """Write *data* back to ``NOTES_FILE``."""
     with NOTES_FILE.open("w", encoding="utf-8") as fh:
-        json.dump(data, fh, indent=2)
+        json.dump(data, fh, indent=2, ensure_ascii=False)
 
 
-def get_current_notes(contact_type: str) -> str:
-    """Return the stored notes for ``contact_type`` or an empty string."""
+def get_current_notes(key: str) -> str:
+    """Return the stored notes for ``key`` or an empty string."""
     data = load_notes()
-    entry = data.get(contact_type, {})
+    entry = data.get(key, {})
     return entry.get("current", "")
 
 
-def update_notes(contact_type: str, new_text: str) -> None:
-    """Replace the notes for ``contact_type`` with ``new_text`` and log history."""
+def update_notes(key: str, new_text: str) -> None:
+    """Replace the notes for ``key`` with ``new_text`` and log history."""
     data = load_notes()
-    entry = data.setdefault(contact_type, {})
+    entry = data.setdefault(key, {})
     entry["current"] = new_text
     history = entry.setdefault("history", [])
     history.append({
@@ -42,17 +43,17 @@ def update_notes(contact_type: str, new_text: str) -> None:
     save_notes(data)
 
 
-def prompt_for_update(contact_type: str) -> None:
-    """Interactively prompt the user to revise notes for ``contact_type``."""
-    current = get_current_notes(contact_type)
+def prompt_for_update(key: str) -> str | None:
+    """Interactively prompt the user to revise notes for ``key``."""
+    current = get_current_notes(key)
     if current:
-        print(f"Current {contact_type} notes:\n{current}\n")
+        print(f"Current notes for {key}:\n{current}\n")
     else:
-        print(f"No existing {contact_type} notes.\n")
+        print(f"No existing notes for {key}.\n")
 
     choice = input("Update these notes? (y/n) ").strip().lower()
     if choice != "y":
-        return
+        return None
 
     print("Enter new notes. Finish with a blank line:")
     lines = []
@@ -64,6 +65,7 @@ def prompt_for_update(contact_type: str) -> None:
     new_text = "\n".join(lines)
     if not new_text:
         print("No changes made.")
-        return
-    update_notes(contact_type, new_text)
+        return None
+    update_notes(key, new_text)
     print("Notes updated.")
+    return new_text


### PR DESCRIPTION
## Summary
- refactor `notes` module to store notes keyed by contact name
- expose contact lookup in `contact_storage`
- add contact list setter in `contact_scheduler`
- update note prompt to show and save notes for the scheduled contact

## Testing
- `python -m py_compile "Morning Helper.py" note_prompt.py contact_scheduler.py notes.py contact_storage.py`

------
https://chatgpt.com/codex/tasks/task_e_684a1b6d3fb48322bdae30d9f007430d