### PR TITLE
Fix verseId param type

### DIFF
--- a/Morning Helper.py
+++ b/Morning Helper.py
@@ -250,7 +250,7 @@ def fetch_daily_dose_hebrew():
                     resp = requests.get(
                         "https://iq-bible.p.rapidapi.com/GetOriginalText",
                         headers=headers,
-                        params={"verseId": verse_id},
+                        params={"verseId": str(verse_id)},
                         timeout=10,
                     )
                     resp.raise_for_status()


### PR DESCRIPTION
## Summary
- ensure the verseId parameter is passed a string when calling the iq-bible API

## Testing
- `python -m py_compile "Morning Helper.py" "contact_scheduler.py" "contact_storage.py" "note_prompt.py" "notes.py"`

------
https://chatgpt.com/codex/tasks/task_e_684b662da5988322b8008f13240c7f57