### PR TITLE
Allow custom LibreOffice path

### DIFF
--- a/Morning Helper.py
+++ b/Morning Helper.py
@@ -156,7 +156,8 @@ def open_translation_spreadsheet(env_var):
 
     # Fallback to launching LibreOffice directly
     try:
-        subprocess.Popen(["libreoffice", "--calc", str(dest)])
+        libreoffice_exe = os.getenv("LIBREOFFICE_EXE", "libreoffice")
+        subprocess.Popen([libreoffice_exe, "--calc", str(dest)])
     except Exception as err:
         print(f"Failed to open translation file {dest}: {err}")
     return dest

--- a/readme.txt
+++ b/readme.txt
@@ -32,9 +32,10 @@ This is a customizable Python script that helps streamline your morning routine 
    - `RAPIDAPI_HOST` – host value for iq-bible API
    - `HEBREW_TRANSLATION_FILE` – path to today's Hebrew translation spreadsheet
    - `GREEK_TRANSLATION_FILE` – path to today's Greek translation spreadsheet
-   - `LibreOffice` should be installed. The translation spreadsheets are
-     standard `.xlsx` files that open and save correctly in LibreOffice Calc;
-     Microsoft Excel is optional.
+   - `LIBREOFFICE_EXE` – *(optional)* full path to the LibreOffice executable.
+     If omitted, the script expects `libreoffice` on your system `PATH`.
+     The translation spreadsheets are standard `.xlsx` files that open and save
+     correctly in LibreOffice Calc; Microsoft Excel is optional.
 
 ## 📇 Contact Data Persistence
 


### PR DESCRIPTION
## Summary
- add optional `LIBREOFFICE_EXE` environment variable
- use the variable when launching LibreOffice
- document the new environment variable

## Testing
- `python -m py_compile 'Morning Helper.py' contact_scheduler.py contact_storage.py note_prompt.py notes.py`

------
https://chatgpt.com/codex/tasks/task_e_684b66ca623c83229654df6f7124ac21