### PR TITLE
Suppress openpyxl header/footer warning

### DIFF
--- a/Morning Helper.py
+++ b/Morning Helper.py
@@ -6,6 +6,7 @@ import time
 import shutil
 import subprocess
 import webbrowser
+import warnings
 from pathlib import Path
 
 try:
@@ -172,6 +173,10 @@ def write_words_to_spreadsheet(file_path, words, start_row=4):
     """
     try:
         from openpyxl import load_workbook
+        warnings.filterwarnings(
+            "ignore",
+            message="Cannot parse header or footer so it will be ignored",
+        )
     except Exception as err:
         print(f"openpyxl not available: {err}")
         return


### PR DESCRIPTION
## Summary
- silence openpyxl's header/footer warning when updating translation spreadsheets
- import `warnings` module to apply filter

## Testing
- `python -m py_compile 'Morning Helper.py'`

------
https://chatgpt.com/codex/tasks/task_e_684bf762fbb08322805b540ae1f63b47